### PR TITLE
New GitHub url for changelog menuitem in main menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.exe
+*.dcu
+*.local
+*.stat
+*.skincfg
+*.map
+*.identcache
+*.dsk
+*.rsm
+*.~*
+*.drc
+*.tvsconfig
+__history
+__recovery

--- a/source/connections.pas
+++ b/source/connections.pas
@@ -1041,6 +1041,8 @@ begin
         updownPort.Position := MakeInt(AppSettings.GetDefaultString(asPort));
       ngMSSQL:
         updownPort.Position := 1433;
+      ngPgSQL:
+        updownPort.Position := 5432;
     end;
   FreeAndNil(Params);
   Modification(Sender);

--- a/source/main.dfm
+++ b/source/main.dfm
@@ -2444,7 +2444,7 @@ object MainForm: TMainForm
     object actWebChangelog: TAction
       Category = 'Various'
       Caption = 'Changelog'
-      Hint = 'https://sourceforge.net/p/heidisql/code/HEAD/log/?path=/'
+      Hint = 'https://github.com/HeidiSQL/HeidiSQL/commits/master'
       ImageIndex = 68
       OnExecute = actWebbrowse
     end


### PR DESCRIPTION
- Change ChangeLog URL in main menu under help to its new GitHub location, instead of old SourceForge address.
- Also a pretty regular .gitignore file to ignore local files, compiled files etc.
- Fix for #36 : Set Port to 5432 when PostgreSQL is selected.