### PR TITLE
renamed helpers.pas unit because of naming conflict

### DIFF
--- a/packages/delphiXE5/heidisql.dpr
+++ b/packages/delphiXE5/heidisql.dpr
@@ -16,7 +16,7 @@ uses
   printlist in '..\..\source\printlist.pas' {printlistForm},
   copytable in '..\..\source\copytable.pas' {CopyTableForm},
   insertfiles in '..\..\source\insertfiles.pas' {frmInsertFiles},
-  helpers in '..\..\source\helpers.pas',
+  heidi_helpers in '..\..\source\heidi_helpers.pas',
   sqlhelp in '..\..\source\sqlhelp.pas' {frmSQLhelp},
   mysql_structures in '..\..\source\mysql_structures.pas',
   column_selection in '..\..\source\column_selection.pas' {ColumnSelectionForm},
@@ -73,7 +73,7 @@ begin
     Application.Title := APPNAME;
     Application.UpdateFormatSettings := False;
     Application.CreateForm(TMainForm, MainForm);
-    MainForm.AfterFormCreate;
+  MainForm.AfterFormCreate;
     Application.OnDeactivate := MainForm.ApplicationDeActivate;
     Application.OnShowHint := MainForm.ApplicationShowHint;
     Application.MainFormOnTaskBar := True;

--- a/packages/delphiXE5/heidisql.dproj
+++ b/packages/delphiXE5/heidisql.dproj
@@ -155,7 +155,7 @@
         <DCCReference Include="..\..\source\insertfiles.pas">
             <Form>frmInsertFiles</Form>
         </DCCReference>
-        <DCCReference Include="..\..\source\helpers.pas"/>
+        <DCCReference Include="..\..\source\heidi_helpers.pas"/>
         <DCCReference Include="..\..\source\sqlhelp.pas">
             <Form>frmSQLhelp</Form>
         </DCCReference>

--- a/source/about.pas
+++ b/source/about.pas
@@ -43,7 +43,7 @@ type
 implementation
 
 uses
-  main, helpers;
+  main, heidi_helpers;
 
 {$R *.DFM}
 

--- a/source/bineditor.pas
+++ b/source/bineditor.pas
@@ -43,7 +43,7 @@ type
 
 implementation
 
-uses helpers, main;
+uses heidi_helpers, main;
 
 
 {$R *.dfm}

--- a/source/change_password.pas
+++ b/source/change_password.pas
@@ -50,7 +50,7 @@ var
 
 implementation
 
-uses main, helpers;
+uses main, heidi_helpers;
 
 {$R *.dfm}
 

--- a/source/column_selection.pas
+++ b/source/column_selection.pas
@@ -4,7 +4,7 @@ interface
 
 uses
   Windows, Classes, Controls, Forms, StdCtrls, CheckLst, ExtCtrls, SysUtils,
-  helpers, gnugettext, extra_controls;
+  heidi_helpers, gnugettext, extra_controls;
 
 type
   TColumnSelectionForm = class(TFormWithSizeGrip)

--- a/source/connections.pas
+++ b/source/connections.pas
@@ -186,7 +186,7 @@ type
 
 implementation
 
-uses Main, helpers, grideditlinks;
+uses Main, heidi_helpers, grideditlinks;
 
 {$I const.inc}
 

--- a/source/copytable.pas
+++ b/source/copytable.pas
@@ -52,7 +52,7 @@ type
 
 implementation
 
-uses helpers, main;
+uses heidi_helpers, main;
 
 const
   nColumns = 0;

--- a/source/createdatabase.pas
+++ b/source/createdatabase.pas
@@ -34,7 +34,7 @@ type
 
 implementation
 
-uses main, helpers;
+uses main, heidi_helpers;
 
 {$R *.dfm}
 

--- a/source/data_sorting.pas
+++ b/source/data_sorting.pas
@@ -5,7 +5,7 @@ interface
 uses
   Windows, SysUtils, Classes, Controls, Forms, StdCtrls, ExtCtrls, ComCtrls, Buttons,
 
-  helpers, gnugettext;
+  heidi_helpers, gnugettext;
 
 
 type

--- a/source/dbconnection.pas
+++ b/source/dbconnection.pas
@@ -761,7 +761,7 @@ var
 
 implementation
 
-uses helpers, loginform, change_password;
+uses heidi_helpers, loginform, change_password;
 
 
 { TProcessPipe }

--- a/source/editvar.pas
+++ b/source/editvar.pas
@@ -48,7 +48,7 @@ type
 
 implementation
 
-uses main, helpers;
+uses main, heidi_helpers;
 
 {$R *.dfm}
 

--- a/source/event_editor.pas
+++ b/source/event_editor.pas
@@ -5,7 +5,7 @@ interface
 uses
   Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms,
   Dialogs, StdCtrls, SynEdit, SynMemo, SynRegExpr, ComCtrls, ExtCtrls, WideStrUtils,
-  helpers, dbconnection, gnugettext;
+  heidi_helpers, dbconnection, gnugettext;
 
 type
   TFrame = TDBObjectEditor;

--- a/source/exportgrid.pas
+++ b/source/exportgrid.pas
@@ -91,7 +91,7 @@ type
 
 implementation
 
-uses main, helpers, dbconnection, mysql_structures;
+uses main, heidi_helpers, dbconnection, mysql_structures;
 
 {$R *.dfm}
 

--- a/source/grideditlinks.pas
+++ b/source/grideditlinks.pas
@@ -7,7 +7,7 @@ interface
 uses
   Windows, Forms, Graphics, Messages, VirtualTrees, ComCtrls, SysUtils, Classes,
   StdCtrls, ExtCtrls, CheckLst, Controls, Types, Dialogs, Menus, Mask, DateUtils, Math,
-  dbconnection, mysql_structures, helpers, texteditor, bineditor, gnugettext,
+  dbconnection, mysql_structures, heidi_helpers, texteditor, bineditor, gnugettext,
   StrUtils, System.UITypes, SynRegExpr;
 
 type

--- a/source/heidi_helpers.pas
+++ b/source/heidi_helpers.pas
@@ -1,4 +1,4 @@
-unit helpers;
+unit heidi_helpers;
 
 
 // -------------------------------------

--- a/source/insertfiles.pas
+++ b/source/insertfiles.pas
@@ -5,7 +5,7 @@ interface
 uses
   Windows, Messages, SysUtils, Classes, Controls, Forms, Dialogs, StdCtrls,
   ShellApi, Math, Graphics, ComCtrls, ToolWin, extra_controls,
-  dbconnection, mysql_structures, VirtualTrees, grideditlinks, SynRegExpr, gnugettext, helpers;
+  dbconnection, mysql_structures, VirtualTrees, grideditlinks, SynRegExpr, gnugettext, heidi_helpers;
 
 type
   TColInfo = class

--- a/source/loaddata.pas
+++ b/source/loaddata.pas
@@ -84,7 +84,7 @@ type
 
 implementation
 
-uses Main, helpers;
+uses Main, heidi_helpers;
 
 {$R *.DFM}
 

--- a/source/loginform.pas
+++ b/source/loginform.pas
@@ -27,7 +27,7 @@ type
 
 implementation
 
-uses helpers, main;
+uses heidi_helpers, main;
 
 {$R *.dfm}
 {$I const.inc}

--- a/source/main.pas
+++ b/source/main.pas
@@ -14,10 +14,11 @@ uses
   ShlObj, SynEditMiscClasses, SynEditSearch, SynEditRegexSearch, SynCompletionProposal, SynEditHighlighter,
   SynHighlighterSQL, Tabs, SynUnicode, SynRegExpr, ExtActns, IOUtils, Types, Themes, ComObj,
   CommCtrl, Contnrs, Generics.Collections, Generics.Defaults, SynEditExport, SynExportHTML, SynExportRTF, Math, ExtDlgs, Registry, AppEvnts,
-  routine_editor, trigger_editor, event_editor, options, EditVar, helpers, createdatabase, table_editor,
+  routine_editor, trigger_editor, event_editor, options, EditVar, heidi_helpers, createdatabase, table_editor,
   TableTools, View, Usermanager, SelectDBObject, connections, sqlhelp, dbconnection,
   insertfiles, searchreplace, loaddata, copytable, VTHeaderPopup, Cromis.DirectoryWatch, SyncDB, gnugettext,
-  JumpList, System.Actions, System.UITypes, pngimage, Vcl.FormsFix;
+  JumpList, System.Actions, System.UITypes, pngimage, Vcl.FormsFix,
+  System.ImageList;
 
 
 type

--- a/source/mysql_structures.pas
+++ b/source/mysql_structures.pas
@@ -7456,7 +7456,7 @@ var
 
 implementation
 
-uses helpers;
+uses heidi_helpers;
 
 function GetFunctionCategories: TStringList;
 var

--- a/source/options.pas
+++ b/source/options.pas
@@ -195,7 +195,7 @@ function EnumFixedProc(lpelf: PEnumLogFont; lpntm: PNewTextMetric; FontType: Int
 
 
 implementation
-uses main, helpers;
+uses main, heidi_helpers;
 {$R *.DFM}
 
 

--- a/source/printlist.pas
+++ b/source/printlist.pas
@@ -34,7 +34,7 @@ type
 
 implementation
 
-uses main, helpers, table_editor, dbconnection;
+uses main, heidi_helpers, table_editor, dbconnection;
 
 {$R *.DFM}
 

--- a/source/routine_editor.pas
+++ b/source/routine_editor.pas
@@ -5,7 +5,7 @@ interface
 uses
   Windows, SysUtils, Classes, Graphics, Controls, Forms, Dialogs, SynEdit, SynMemo, StdCtrls,
   ComCtrls, ToolWin, VirtualTrees, SynRegExpr,
-  dbconnection, helpers, gnugettext, Vcl.Menus, Vcl.ExtCtrls;
+  dbconnection, heidi_helpers, gnugettext, Vcl.Menus, Vcl.ExtCtrls;
 
 type
   TFrame = TDBObjectEditor;

--- a/source/searchreplace.pas
+++ b/source/searchreplace.pas
@@ -54,7 +54,7 @@ implementation
 
 {$R *.dfm}
 
-uses helpers, main;
+uses heidi_helpers, main;
 
 
 procedure TfrmSearchReplace.FormCreate(Sender: TObject);

--- a/source/selectdbobject.pas
+++ b/source/selectdbobject.pas
@@ -44,7 +44,7 @@ function SelectDBObjects: TDBObjectList;
 
 implementation
 
-uses main, helpers;
+uses main, heidi_helpers;
 
 {$R *.dfm}
 

--- a/source/sqlhelp.pas
+++ b/source/sqlhelp.pas
@@ -71,7 +71,7 @@ type
 
 implementation
 
-uses helpers, main;
+uses heidi_helpers, main;
 
 {$I const.inc}
 

--- a/source/syncdb.pas
+++ b/source/syncdb.pas
@@ -75,7 +75,7 @@ type
 
 implementation
 
-uses main, helpers;
+uses main, heidi_helpers;
 
 {$R *.dfm}
 

--- a/source/table_editor.pas
+++ b/source/table_editor.pas
@@ -6,7 +6,7 @@ uses
   Windows, SysUtils, Classes, Graphics, Controls, Forms, Dialogs, StdCtrls,
   ComCtrls, ToolWin, VirtualTrees, SynRegExpr, ActiveX, ExtCtrls, SynEdit,
   SynMemo, Menus, Clipbrd, Math, System.UITypes,
-  grideditlinks, mysql_structures, dbconnection, helpers, gnugettext;
+  grideditlinks, mysql_structures, dbconnection, heidi_helpers, gnugettext;
 
 type
   TFrame = TDBObjectEditor;

--- a/source/tabletools.pas
+++ b/source/tabletools.pas
@@ -11,7 +11,7 @@ interface
 uses
   Windows, SysUtils, Classes, Controls, Forms, StdCtrls, ComCtrls, Buttons, Dialogs, StdActns,
   VirtualTrees, ExtCtrls, Graphics, SynRegExpr, Math, Generics.Collections, extra_controls,
-  dbconnection, helpers, Menus, gnugettext, DateUtils, System.Zip, System.UITypes, StrUtils;
+  dbconnection, heidi_helpers, Menus, gnugettext, DateUtils, System.Zip, System.UITypes, StrUtils;
 
 type
   TToolMode = (tmMaintenance, tmFind, tmSQLExport, tmBulkTableEdit);

--- a/source/texteditor.pas
+++ b/source/texteditor.pas
@@ -5,7 +5,7 @@ interface
 uses
   Windows, Classes, Graphics, Forms, Controls, StdCtrls, VirtualTrees,
   ComCtrls, ToolWin, Dialogs, SysUtils, Menus, ExtDlgs,
-  helpers, gnugettext, ActnList, StdActns, extra_controls, System.Actions,
+  heidi_helpers, gnugettext, ActnList, StdActns, extra_controls, System.Actions,
   Vcl.ExtCtrls;
 
 {$I const.inc}

--- a/source/trigger_editor.pas
+++ b/source/trigger_editor.pas
@@ -5,7 +5,7 @@ interface
 uses
   Windows, SysUtils, Classes, Controls, Forms, Dialogs, StdCtrls, SynEdit, SynMemo,
   SynCompletionProposal, SynRegExpr,
-  dbconnection, mysql_structures, helpers, gnugettext, ComCtrls;
+  dbconnection, mysql_structures, heidi_helpers, gnugettext, ComCtrls;
 
 type
   TFrame = TDBObjectEditor;

--- a/source/updatecheck.pas
+++ b/source/updatecheck.pas
@@ -4,7 +4,7 @@ interface
 
 uses
   Windows, Messages, SysUtils, Classes, Forms, StdCtrls, IniFiles, Controls, Graphics,
-  helpers, gnugettext, ExtCtrls;
+  heidi_helpers, gnugettext, ExtCtrls;
 
 type
   TfrmUpdateCheck = class(TForm)

--- a/source/usermanager.pas
+++ b/source/usermanager.pas
@@ -6,7 +6,7 @@ interface
 uses
   Windows, Messages, SysUtils, Classes, Graphics, Controls, Forms, Dialogs, ComCtrls, StdCtrls,
   ExtCtrls, ToolWin, ClipBrd, Generics.Collections, Generics.Defaults, SynRegExpr, extra_controls,
-  dbconnection, helpers, VirtualTrees, Menus, gnugettext;
+  dbconnection, heidi_helpers, VirtualTrees, Menus, gnugettext;
 
 {$I const.inc}
 

--- a/source/view.pas
+++ b/source/view.pas
@@ -5,7 +5,7 @@ interface
 uses
   Windows, SysUtils, Classes, Graphics, Controls, Forms, Dialogs, StdCtrls, SynEdit, SynMemo,
   ExtCtrls,
-  dbconnection, mysql_structures, helpers, gnugettext;
+  dbconnection, mysql_structures, heidi_helpers, gnugettext;
 
 type
   TFrame = TDBObjectEditor;


### PR DESCRIPTION
renamed helpers.pas unit to heidi_helpers.pas because of naming conflict with FireMonkeys FMX.Canvas.GPU.Helpers unit. Changed all places where that unit is used.

This was preventing the application from getting compiled on a delphi version that also has FireMonkey.