### PR TITLE
Switch to Microsoft OLE DB Driver for SQL Server

### DIFF
--- a/source/dbconnection.pas
+++ b/source/dbconnection.pas
@@ -1858,7 +1858,7 @@ begin
       QuotedPassword := ''''+Parameters.Password+''''
     else
       QuotedPassword := '"'+Parameters.Password+'"';
-    FAdoHandle.ConnectionString := 'Provider=SQLOLEDB;'+
+    FAdoHandle.ConnectionString := 'Provider=MSOLEDBSQL;'+
       'Password='+QuotedPassword+';'+
       'Persist Security Info=True;'+
       'User ID='+Parameters.Username+';'+
@@ -1870,7 +1870,7 @@ begin
     if (not Parameters.AllDatabasesStr.IsEmpty) and (Pos(';', Parameters.AllDatabasesStr)=0) then
       FAdoHandle.ConnectionString := FAdoHandle.ConnectionString + 'Database='+Parameters.AllDatabasesStr+';';
     if Parameters.WindowsAuth then
-      FAdoHandle.ConnectionString := FAdoHandle.ConnectionString + 'Integrated Security=SSPI;';
+      FAdoHandle.ConnectionString := FAdoHandle.ConnectionString + 'Trusted_Connection=yes;';
     try
       FAdoHandle.Connected := True;
       FConnectionStarted := GetTickCount div 1000;


### PR DESCRIPTION
SQLOLEDB provider is for deprecated Microsoft OLE DB Provider for SQL
Server, which is no longer supported.

See https://blogs.msdn.microsoft.com/sqlnativeclient/2017/10/06/announcing-the-new-release-of-ole-db-driver-for-sql-server/

Fixes #237 

NOTE: I don't have a Delphi compiler handy, so could not test this. Community help would be appreciated.