### PR TITLE
Free PGconn on connection failure

### DIFF
--- a/source/dbconnection.pas
+++ b/source/dbconnection.pas
@@ -2083,6 +2083,7 @@ begin
       Error := LastErrorMsg;
       Log(lcError, Error);
       FConnectionStarted := 0;
+      PQfinish(FHandle); // free the memory
       FHandle := nil;
       raise EDatabaseError.Create(Error);
     end;


### PR DESCRIPTION
The PG doc says: Note that even if the server connection attempt fails (as indicated by PQstatus), the application should call PQfinish to free the memory used by the PGconn object.
I do not see that PQfinish is (explicitly) called when PQstatus is bad
Note: other rows are bc new-line endings auto convert, you can ignore them
Note 2: I do not have Delphi, it's not tested, based on code review only 