### PR TITLE
VIEW parsing: accept DEFINER with ` and spaces

### DIFF
--- a/source/dbconnection.pas
+++ b/source/dbconnection.pas
@@ -5323,7 +5323,9 @@ begin
     rx.ModifierI := True;
     rx.Expression := 'CREATE\s+(OR\s+REPLACE\s+)?'+
       '(ALGORITHM\s*=\s*(\w*)\s*)?'+
-      '(DEFINER\s*=\s*(\S+)\s+)?'+
+      '(DEFINER\s*=\s*('+
+        '\S+|`[^`]*`(?:@(?:\S+|`[^`]*`)?)?'+
+      ')\s+)?'+
       '(SQL\s+SECURITY\s+(\S+)\s+)?'+
       'VIEW\s+[^\(]+\s+'+
       '(\([^\)]+\)\s+)?'+


### PR DESCRIPTION
When parsing VIEW codes, we may have that `DEFINER` values may contain spaces, for example:

    DEFINER=`skip-grants user`@skip-grants host`

In this example, `` `skip-grants user`@`skip-grants host` `` does not match the `\S+` regular expression, and HeidiSQL crashes with this error message:

    Regular expression did not match the VIEW code in ParseViewStructure()

So, what about accepting also values with spaces enclosed in backticks?

This PR changes the `\S+` chunk to this one:

    \S+|`[^`]*`(?:@(?:\S+|`[^`]*`)?)?

which means:

- `\S+` → any non-whitespace characters
- `|` → or
- `` `[^`]*` `` → a backtick, followed by any number of non backticks, then a backtick
- `(...)?` → optionally followed by (`?:` → without capturing it):
  - `@` → the *at* character
  - `(...)?` → optionally followed by (`?:` → without capturing it):
    - `\S+` → any non-whitespace characters
    - `|` → or
    - `` `[^`]*` `` → a backtick, followed by any number of non backticks, then a backtick