### PR TITLE
Don't trim items when exploding to string list for export to RTF

### DIFF
--- a/source/apphelpers.pas
+++ b/source/apphelpers.pas
@@ -444,7 +444,7 @@ begin
         Result.Add(Text);
       break;
     end;
-    Item := Trim(Copy(Text, 1, i-1));
+    Item := Copy(Text, 1, i-1);
     Result.Add(Item);
     Delete(Text, 1, i-1+Length(Separator));
   end;


### PR DESCRIPTION
Currently, when copying a SQL script from the SynEdit control, the RTF part loses indentation, e.g. if I have this script:

```sql
CREATE TABLE /*!32312 IF NOT EXISTS*/ tableB (
  id INT,
  name VARCHAR(30) DEFAULT "standard"
)
```
and I copy it to the clipboard , then the RTF part is
```
{\rtf1\ansi\ansicpg1252\uc1\deff0\deftab720{\fonttbl{\f0\fmodern Courier New;}}
{\colortbl\red0\green0\blue255;\red0\green0\blue0;\red128\green128\blue128;\red128\green128\blue0;\red128\green0\blue0;\red128\green0\blue128;}
{\info{\comment Generated by the SynEdit RTF exporter}
{\title Untitled}}
\deflang1033\pard\plain\f0\fs20 \cf0\b CREATE\b0\cf1  \cf0\b TABLE\b0\cf1  \cf2\i /*!32312 IF NOT EXISTS*/\i0\cf1  \cf3 tableB\cf1  \cf0 (
\par \cf3 id\cf1  \cf4\b INT\b0\cf0 ,
\par \cf3 name\cf1  \cf4\b VARCHAR\b0\cf0 (\cf5 30\cf0 )\cf1  \cf0\b DEFAULT\b0\cf1  \cf3 "standard"
\par \cf0 )
\par }
```

which renders to:
![image](https://user-images.githubusercontent.com/145854/75918221-00b7af80-5e64-11ea-8b5c-403a8323f14e.png)

This PR adds an optional parameter to the `Explode` method to optionally *not* trim the items before being added to the string list. When copying, this optional parameter is set to `false`. All other uses of the method is unaffected.

After the fix, RTF rendered is:
![image](https://user-images.githubusercontent.com/145854/75918335-39f01f80-5e64-11ea-99e1-1d8cd9dbbe4a.png)
