### PR TITLE
Remove closing PHP tag from export as PHP array

### DIFF
--- a/source/exportgrid.pas
+++ b/source/exportgrid.pas
@@ -1048,8 +1048,6 @@ begin
         tmp := '\end{tabular}' + CRLF;
       efPHPArray: begin
         tmp := ');' + CRLF;
-        if radioOutputFile.Checked then
-          tmp := tmp + '?>';
       end;
       efJSON: begin
         S.Size := S.Size - 1;


### PR DESCRIPTION
[From the PHP manual](https://www.php.net/manual/en/language.basic-syntax.instruction-separation.php#example-41):

> The closing tag of a PHP block at the end of a file is optional, and in some cases omitting it is helpful when using include or require, so unwanted whitespace will not occur at the end of files, and you will still be able to add headers to the response later. It is also handy if you use output buffering, and would not like to see added unwanted whitespace at the end of the parts generated by the included files.