### PR TITLE
[WIP] follow foreign key to the reference table and filter to show only rows linked from the current row

### DIFF
--- a/source/main.dfm
+++ b/source/main.dfm
@@ -2374,6 +2374,13 @@ object MainForm: TMainForm
       ImageName = 'icons8-close-button'
       OnExecute = actExitApplicationExecute
     end
+    object actFollowForeignKey: TAction
+      Category = 'Various'
+      Caption = 'Follow Foreign Key'
+      Hint = 'Follow foreign key to the linked table'
+      ImageIndex = 61
+      OnExecute = actFollowForeignKeyExecute
+    end
     object actCopy: TAction
       Category = 'Various'
       Caption = '&Copy'
@@ -3785,6 +3792,9 @@ object MainForm: TMainForm
     OnPopup = popupDataGridPopup
     Left = 200
     Top = 248
+    object FollowForeignKey: TMenuItem
+      Action = actFollowForeignKey
+    end
     object Copy3: TMenuItem
       Action = actCopy
     end


### PR DESCRIPTION
This a work-in-progress branch to implement a solution for #156.
I added a menu item "Follow Foreign Key" to jump to the linked row in the reference table.

However, there are some bugs:
* sometimes the filter was added but not used immediately. I have to select it from the "Recent filters" and apply it.
* if the current column contains thousand separators, then the filter will be wrong (such as  id="1,230,450")

@ansgarbecker Please give me some hint because I'm not familiar with Delphi and Pascal. And it would be better if I can put an icon inside the column and click on that icon to jump (instead of using a menu item).