### PR TITLE
Change thead table font colour to be different than background

### DIFF
--- a/source/exportgrid.pas
+++ b/source/exportgrid.pas
@@ -623,7 +623,7 @@ begin
           '    <meta name="GENERATOR" content="'+ APPNAME+' '+Mainform.AppVersion + '">' + CRLF +
           '    <meta http-equiv="Content-Type" content="text/html; charset='+GetHTMLCharsetByEncoding(Encoding)+'" />' + CRLF +
           '    <style type="text/css">' + CRLF +
-          '      thead tr {background-color: ActiveCaption; color: CaptionText;}' + CRLF +
+          '      thead tr {background-color: ActiveCaption; color: White;}' + CRLF +
           '      th, td {vertical-align: top; font-family: "'+Grid.Font.Name+'", Arial, Helvetica, sans-serif; font-size: '+IntToStr(Grid.Font.Size)+'pt; padding: '+IntToStr(Grid.TextMargin-1)+'px; }' + CRLF +
           '      table, td {border: 1px solid silver;}' + CRLF +
           '      table {border-collapse: collapse;}' + CRLF;


### PR DESCRIPTION
Well in html export feature we have a problem with thead colour that is black and font is also black so you can't read them until you change the colour in exported html or select them like in my capture below:

![sqz](https://user-images.githubusercontent.com/24683355/216820056-0dbd35ac-cbb1-4e9e-aa8e-bde928bcc4b9.PNG)
