### PR TITLE
Fix version.rc build failures in Delphi 12.1

### DIFF
--- a/res/version.rc
+++ b/res/version.rc
@@ -1,20 +1,29 @@
-1 VERSIONINFO
-  FILEVERSION 12,10,0,0
-  FILEOS VOS__WINDOWS32
-  FILETYPE VFT_APP
-  BEGIN
-    BLOCK "StringFileInfo"
-    BEGIN
-      BLOCK "040904E4"
-      BEGIN
-        VALUE "FileDescription", "%APPNAME% %APPVER%\000"
-        VALUE "ProductName", "%APPNAME%\000"
-        VALUE "LegalCopyright", "Ansgar Becker, see gpl.txt\000"
-      END
-    END
-    BLOCK "VarFileInfo"
-    BEGIN
-      VALUE "Translation", 0x0409 0x04E4
-    END 
-  END
+#include <winver.h>
 
+1 VERSIONINFO
+  FILEVERSION     12,10,0,0
+  PRODUCTVERSION  12,10,0,0
+  FILEFLAGSMASK   0x3fL
+  FILEFLAGS       0x0L
+  FILEOS          VOS__WINDOWS32
+  FILETYPE        VFT_APP
+  FILESUBTYPE     0x0L
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904E4"
+    BEGIN
+      VALUE "FileDescription",  "%APPNAME% %APPVER%\000"
+      VALUE "ProductName",      "%APPNAME%\000"
+      VALUE "FileVersion",      "%APPVER%\000"
+      VALUE "ProductVersion",   "%APPVER%\000"
+      VALUE "InternalName",     "%APPNAME%.exe\000"
+      VALUE "OriginalFilename", "%APPNAME%.exe\000"
+      VALUE "LegalCopyright",   "Ansgar Becker, see gpl.txt\000"
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0409, 1252
+  END
+END


### PR DESCRIPTION
Fix: Make version.rc compile successfully under Delphi 12.1

Previously, version.rc failed to compile due to missing macro definitions like VOS__WINDOWS32. This update adds `#include <winver.h>` and fills out standard VERSIONINFO fields, restoring compatibility with the Delphi 12.1 resource compiler.

- Resolves RC2104 (undefined keyword) and RC1015 (missing include)
- Retains %APPNAME% and %APPVER% placeholders for Delphi substitutions
- No changes to build behavior — just unblocks successful compilation

Tested with Delphi 12.1 CE (`rc.exe`) and Microsoft Windows SDK resource compiler.