### PR TITLE
Fixed EAccessViolation when closing editor while using non-default theme

### DIFF
--- a/source/texteditor.pas
+++ b/source/texteditor.pas
@@ -288,6 +288,9 @@ begin
     AppSettings.SessionPath := MainForm.GetRegKeyTable;
     AppSettings.WriteString(asMemoEditorHighlighter, comboHighlighter.Text, FTableColumn.Name);
   end;
+  // Fixes EAccessViolation under 64-bit when using non-default themes
+  if Assigned(Panel1) then
+    Panel1.Parent := nil;
 end;
 
 


### PR DESCRIPTION
This PR is a bugfix for #2187.  

Under 64-bit binaries, when using any style theme besides Windows, you get a EAccessViolation when you try to save or otherwise close the text editor form. 