### PR TITLE
TRIGGER parsing: accept trigger and table names without quote characters

### DIFF
--- a/source/trigger_editor.pas
+++ b/source/trigger_editor.pas
@@ -122,7 +122,7 @@ begin
     rx := TRegExpr.Create;
     rx.ModifierI := True;
     QuoteCharsRx := QuoteRegExprMetaChars(DBObject.Connection.QuoteChars);
-    QuotedWordRx := '['+QuoteCharsRx+'][^'+QuoteCharsRx+']+['+QuoteCharsRx+']';
+    QuotedWordRx := '['+QuoteCharsRx+']?[^'+QuoteCharsRx+']+['+QuoteCharsRx+']?';
     rx.Expression := '(\sDEFINER=('+QuotedWordRx+'@'+QuotedWordRx+'))?' +
       '\s+TRIGGER\s+'+QuotedWordRx +
       '\s+('+Implode('|', comboTiming.Items)+')' +
@@ -310,3 +310,4 @@ end;
 
 
 end.
+


### PR DESCRIPTION
This is my attempt at fixing #2299.

This change makes the character groups with the quote characters optional, therefore enabling triggers with trigger names or table names without quote characters to be parsed. 

I tested the updated regular expression with different cases, ensuring it works with `, ", and without. 
<img width="849" height="754" alt="image" src="https://github.com/user-attachments/assets/3148a93a-ff0d-465e-a5af-c58ed3ea2a2e" />

I didn't build the software, therefore I don't know if this change breaks anything. Still hope this helps!