### PR TITLE
fix: MSSQL foreign key lookup to include table schema

### DIFF
--- a/source/dbconnection.pas
+++ b/source/dbconnection.pas
@@ -6448,14 +6448,17 @@ begin
   ForeignQuery := GetResults('SELECT'+
     '   f.name AS foreign_key_name,'+
     '   COL_NAME(fc.parent_object_id, fc.parent_column_id) AS constraint_column_name,'+
-    '   OBJECT_NAME (f.referenced_object_id) AS referenced_object,'+
+    '   SCHEMA_NAME(ro.schema_id) AS referenced_schema,'+
+    '   OBJECT_NAME(f.referenced_object_id) AS referenced_object,'+
     '   COL_NAME(fc.referenced_object_id, fc.referenced_column_id) AS referenced_column_name,'+
     '   update_referential_action_desc,'+
     '   delete_referential_action_desc'+
     ' FROM sys.foreign_keys AS f'+
     ' INNER JOIN sys.foreign_key_columns AS fc'+
     '   ON f.object_id = fc.constraint_object_id'+
-    ' WHERE f.parent_object_id = OBJECT_ID('+EscapeString(Table.Name)+')'
+    ' INNER JOIN sys.objects AS ro'+
+    '   ON ro.object_id = f.referenced_object_id'+
+    ' WHERE f.parent_object_id = OBJECT_ID('+EscapeString(Table.QuotedDbAndTableName)+')'
     );
   ForeignKey := nil;
   while not ForeignQuery.Eof do begin
@@ -6464,7 +6467,8 @@ begin
       Result.Add(ForeignKey);
       ForeignKey.KeyName := ForeignQuery.Col('foreign_key_name');
       ForeignKey.OldKeyName := ForeignKey.KeyName;
-      ForeignKey.ReferenceTable := ForeignQuery.Col('referenced_object');
+      ForeignKey.ReferenceTable :=
+        ForeignQuery.Col('referenced_schema') + '.' + ForeignQuery.Col('referenced_object');
       ForeignKey.OnUpdate := ForeignQuery.Col('update_referential_action_desc');
       ForeignKey.OnDelete := ForeignQuery.Col('delete_referential_action_desc');
     end;


### PR DESCRIPTION
Use the fully qualified database/schema/table name when resolving OBJECT_ID() for MSSQL foreign key metadata. This prevents SQL Server from implicitly resolving tables under dbo when the table belongs to another schema.

Also include the referenced table schema in the foreign key metadata so references to non-dbo tables are preserved correctly.

Refs #2462