### PR TITLE
fix: prevent access violation on session disconnect (nil ActivePage)

### DIFF
--- a/source/main.pas
+++ b/source/main.pas
@@ -6332,6 +6332,10 @@ begin
     Exit;
 
   tab := PageControlMain.ActivePage;
+  // ActivePage can be nil while tabs are being hidden during session teardown (disconnect),
+  // which would raise an access violation below on tab.PageIndex.
+  if tab = nil then
+    Exit;
   // Query helpers need a hit here, since RefreshHelperNode now only does its update on the active tab
   // See https://www.heidisql.com/forum.php?t=37961
   RefreshHelperNode(TQueryTab.HelperNodeColumns);


### PR DESCRIPTION
Fixes #2509

On the Cocoa widgetset, disconnecting a session can raise an EAccessViolation. Removing the connection's tree nodes triggers a focus change that hides tabs, which fires PageControlMain.OnChange while PageControlMain.ActivePage is transiently nil; PageControlMainChange then dereferences tab.PageIndex on the nil tab.

Guard against a nil ActivePage, matching the existing "not Self.Visible" early-exit guard.