### PR TITLE
fix: crash when cancelling the session manager on macOS (#2433)

### DIFF
--- a/source/apphelpers.pas
+++ b/source/apphelpers.pas
@@ -3528,7 +3528,11 @@ end;
 procedure TWinControlHelper.TrySetFocus;
 begin
   try
-    if Enabled and CanFocus then
+    // CanSetFocus - unlike CanFocus - also tests the parent form itself, so
+    // this avoids the "[TCustomForm.SetFocus] ... Can not focus" exception
+    // which SetFocus raises on a hidden or disabled form, e.g. while a modal
+    // form is closing. See issue 2433.
+    if CanSetFocus then
       SetFocus
     else
       MainForm.LogSQL(Self.Name + ': either disabled or cannot focus', lcDebug);

--- a/source/connections.pas
+++ b/source/connections.pas
@@ -384,6 +384,12 @@ procedure Tconnform.FormCloseQuery(Sender: TObject; var CanClose: Boolean);
 begin
   // Modifications? Ask if they should be saved.
   FinalizeModifications(CanClose);
+  // End a pending inline rename while the form is still visible and active.
+  // Otherwise the edit link tries to restore the focus during form teardown,
+  // which raises "[TCustomForm.SetFocus] ... Can not focus" on macOS.
+  // See issue #2433.
+  if CanClose and ListSessions.IsEditing then
+    ListSessions.CancelEditNode;
 end;
 
 

--- a/source/grideditlinks.pas
+++ b/source/grideditlinks.pas
@@ -279,6 +279,11 @@ var
   NewNode: PVirtualNode;
   DoPrev: Boolean;
 begin
+  // Drop end/cancel calls which are still queued via DoEndEdit/DoCancelEdit.
+  // They would fire after this link - and possibly the tree or its form - is
+  // already destroyed, e.g. when the session manager is cancelled while a
+  // session rename is active. See issue #2433.
+  Application.RemoveAsyncCalls(Self);
   ActiveGridEditor := nil;
   if Assigned(FMainControl) then begin
     FMainControl.WindowProc := FOldWindowProc;

--- a/source/main.pas
+++ b/source/main.pas
@@ -1776,10 +1776,28 @@ begin
     CanClose := not (ActiveObjectEditor.DeInit in [mrAbort, mrCancel]);
 end;
 
+{$IFDEF DARWIN}
+type
+  // Grants access to the protected DestroyHandle, see workaround in FormDestroy
+  TWinControlAccess = class(TWinControl);
+{$ENDIF}
+
 procedure TMainForm.FormDestroy(Sender: TObject);
 begin
   // Discard a possibly queued AsyncRepaintGrid call
   Application.RemoveAsyncCalls(Self);
+
+  {$IFDEF DARWIN}
+  // Work around a SynEdit bug which crashes the app on every shutdown on Cocoa:
+  // TSynBaseCompletionForm.Destroy first frees its SizeDrag panel and then
+  // destroys the window handle. The Cocoa widgetset queries Focused while
+  // destroying the handle, and the Focused override dereferences the already
+  // freed SizeDrag ("EObjectCheck: Object reference is Nil"). Destroying the
+  // handle here, while the form is still intact, makes the destructor skip
+  // that path. See issue 2433.
+  if SynCompletionProposal.TheForm.HandleAllocated then
+    TWinControlAccess(SynCompletionProposal.TheForm).DestroyHandle;
+  {$ENDIF}
 
   // Destroy dialogs
   FreeAndNil(FSearchReplaceDialog);


### PR DESCRIPTION
Two independent crashes on macOS were hidden behind this repro, since cancelling the session manager at startup also exits the application:

1. The session manager starts an inline rename right after creating a new session. When the form was closed via Cancel, the edit link's queued async EndEditNode call fired after the tree was already destroyed, and its focus restoration ran into "[TCustomForm.SetFocus] connform:Tconnform Can not focus". Remove pending async edit calls when an editor link is destroyed, cancel a pending inline rename before the form closes, and add a SetFocusSafe() helper based on CanSetFocus, which - unlike CanFocus - also checks the parent form itself.

2. On shutdown, TSynBaseCompletionForm.Destroy (SynEdit) first frees its SizeDrag panel and then destroys the window handle. The Cocoa widgetset queries Focused during DestroyHandle, and SynEdit's Focused override dereferences the freed SizeDrag, raising "EObjectCheck: Object reference is Nil" on every macOS shutdown. Work around it by destroying the completion form's handle in FormDestroy while the form is still intact.

Verified on an M5 MacBook Pro (macOS 26) under lldb with breakpoints on FPC_RAISEEXCEPTION / FPC_CHECK_OBJECT: before the fix both exceptions fired; after the fix the app exits cleanly with status 0.

Fixes #2433
