### PR TITLE
fix: data grid header keeps showing previous table's columns on macOS

### DIFF
--- a/source/main.pas
+++ b/source/main.pas
@@ -1332,6 +1332,9 @@ type
     procedure ToggleFilterPanel(ForceVisible: Boolean = False);
     procedure EnableDataTab(Enable: Boolean);
     procedure AutoCalcColWidth(Tree: TVirtualStringTree; Column: TColumnIndex);
+    {$IFDEF DARWIN}
+    procedure AsyncRepaintGrid(Data: PtrInt);
+    {$ENDIF}
     procedure PlaceObjectEditor(Obj: TDBObject);
     procedure SetTabCaption(PageIndex: Integer; Text: String);
     function ConfirmTabClose(PageIndex: Integer; AppIsClosing: Boolean): Boolean;
@@ -1777,6 +1780,11 @@ end;
 
 procedure TMainForm.FormDestroy(Sender: TObject);
 begin
+  {$IFDEF DARWIN}
+  // Discard a possibly queued AsyncRepaintGrid call
+  Application.RemoveAsyncCalls(Self);
+  {$ENDIF}
+
   // Destroy dialogs
   FreeAndNil(FSearchReplaceDialog);
 
@@ -6299,11 +6307,28 @@ begin
     if Integer(vt.RootNodeCount) = MaximumRows then
       LogSQL(f_('Browsing is currently limited to a maximum of %s rows. To see more rows, increase this maximum in %s > %s > %s.', [FormatNumber(MaximumRows), _('Tools'), _('Preferences'), _('Data')]), lcInfo);
   end;
+  {$IFDEF DARWIN}
+  // This procedure runs inside a paint cycle of the grid, and Cocoa discards
+  // invalidations issued while a paint cycle is running. The header was already
+  // painted before OnBeforePaint fired, so it would keep showing the previous
+  // table's columns until some unrelated event repaints the window. Queue a
+  // repaint which runs right after the current paint cycle.
+  Application.QueueAsyncCall(AsyncRepaintGrid, PtrInt(vt));
+  {$ENDIF}
   vt.Tag := VTREE_LOADED;
   DataGridFullRowMode := False;
   Screen.Cursor := crDefault;
   ShowStatusMsg;
 end;
+
+
+{$IFDEF DARWIN}
+procedure TMainForm.AsyncRepaintGrid(Data: PtrInt);
+begin
+  // Deferred repaint, queued in DataGridBeforePaint
+  TBaseVirtualTree(Data).Invalidate;
+end;
+{$ENDIF}
 
 
 procedure TMainForm.DataGridColumnResize(Sender: TVTHeader; Column: TColumnIndex);


### PR DESCRIPTION
Fixes #2548

On macOS, loading the data grid happens inside a paint cycle (`OnBeforePaint`), and Cocoa discards invalidations issued while a paint cycle is running. The header is painted before `OnBeforePaint` fires, so after switching tables it kept showing the previous table's columns until some unrelated event repainted the window (scroll, resize or focus change). Full root cause analysis with lldb backtraces is in the issue.

This change queues one asynchronous repaint (`Application.QueueAsyncCall`) at the end of `DataGridBeforePaint`, which runs right after the current paint cycle finishes, so the new header becomes visible immediately. No query re-execution, and everything is inside `{$IFDEF DARWIN}`, so Windows and Linux builds are byte-identical.

Tested on an M5 Mac: headers now update instantly on every table switch, and sort arrows / column numbering are correct as well.