### PR TITLE
Fix hang and wrong check states in data grid column selection on macOS

### DIFF
--- a/source/column_selection.pas
+++ b/source/column_selection.pas
@@ -150,20 +150,20 @@ end;
 }
 procedure TfrmColumnSelection.chklistColumnsClickCheck(Sender: TObject);
 var
-  i : Integer;
+  i, CheckedIndex : Integer;
   AllSelected, NoneSelected : Boolean;
-  FocusedItem: String;
-  FocusedItemIndex: Integer;
 begin
-  // Add or remove clicked item from list
-  if chklistColumns.ItemIndex > -1 then begin
-    FocusedItem := chklistColumns.Items[chklistColumns.ItemIndex];
-    if chklistColumns.Checked[chklistColumns.ItemIndex] then begin
-      FCheckedColumns.Add(FocusedItem)
+  // Sync check states of all displayed items into FCheckedColumns. Using
+  // ItemIndex to detect the clicked item would be wrong on macOS, where the
+  // check event fires before the list selection is updated. See issue 2554.
+  for i:=0 to chklistColumns.Items.Count-1 do begin
+    CheckedIndex := FCheckedColumns.IndexOf(chklistColumns.Items[i]);
+    if chklistColumns.Checked[i] then begin
+      if CheckedIndex = -1 then
+        FCheckedColumns.Add(chklistColumns.Items[i]);
     end else begin
-      FocusedItemIndex := FCheckedColumns.IndexOf(FocusedItem);
-      if FocusedItemIndex > -1 then
-        FCheckedColumns.Delete(FocusedItemIndex);
+      if CheckedIndex > -1 then
+        FCheckedColumns.Delete(CheckedIndex);
     end;
   end;
 
@@ -225,6 +225,7 @@ procedure TfrmColumnSelection.FormDestroy(Sender: TObject);
 begin
   AppSettings.WriteInt(asColumnSelectorWidth, ScaleFormToDesign(Width));
   AppSettings.WriteInt(asColumnSelectorHeight, ScaleFormToDesign(Height));
+  FCheckedColumns.Free;
 end;
 
 
@@ -243,8 +244,9 @@ end;
 procedure TfrmColumnSelection.FormClose(Sender: TObject; var Action:
     TCloseAction);
 begin
+  // FormClose can run twice when the form is closed by OK and afterwards
+  // deactivated - free FCheckedColumns in FormDestroy only. See issue 2554.
   Action := caFree;
-  FCheckedColumns.Free;
 end;
 
 


### PR DESCRIPTION
Fixes #2554

Debugged with lldb on an M-series Mac. There were two separate bugs in the column selection popup, both fixed here:

**1. The reported hang (double-free of FCheckedColumns)**

Clicking OK closes the popup, which frees `FCheckedColumns` in `FormClose`. But the form itself is only released deferred (`caFree`), and the grid reload triggered by OK makes the main window key again *while the popup object still exists*. The LCL then sends `CM_DEACTIVATE` to the popup → `FormDeactivate` → `btnCancelClick` → `Close` runs a **second** time → `FCheckedColumns.Free` on the already freed list. The resulting access violation raises the crash dialog with `ShowModal` inside the data grid's paint cycle, where nothing can be drawn anymore - the app freezes with an invisible modal dialog.

Backtrace of the crash (captured with lldb, trimmed):
frame #1: SYSTEM$$TOBJECT$$$FREE
frame #2: TFRMCOLUMNSELECTION$$$FORMCLOSE ← 2nd time
frame #5: TFRMCOLUMNSELECTION$$$BTNCANCELCLICK
frame #6: TFRMCOLUMNSELECTION$$$FORMDEACTIVATE
frame #14: TSCREEN$$$SETFOCUSEDFORM
frame #23: -[TCocoaWindow windowDidBecomeKey:]
frame #31: -[NSWindow makeKeyWindow]
frame #38: APPHELPERS$$$TRYSETFOCUS
frame #39: TMAINFORM$__$$_DATAGRIDBEFOREPAINT ← grid reload after OK


Fix: free `FCheckedColumns` in `FormDestroy`, which runs exactly once. `TApplication.ReleaseComponent` already tolerates the duplicate `Release`, so the second close pass is harmless otherwise.

**2. Checked columns were applied wrongly (stale ItemIndex)**

After fixing the hang, selecting e.g. 3 columns still showed only 1 in the grid. `chklistColumnsClickCheck` used `chklistColumns.ItemIndex` to detect the toggled item. On Cocoa the checkbox is an `NSButton` inside the table row, and its action fires **before** the table selection is updated - so `ItemIndex` still points at the *previously* clicked row, or is -1. Verified with lldb: clicking checkboxes of rows 0, 2, 1 delivered `LM_CHANGED` for rows 0, 2, 1 while `selectedRow` was -1, 0, 4 at those moments - the internal list diverged from the visible check marks on every click.

Fix: sync the check states of all currently displayed items into `FCheckedColumns` instead of guessing via `ItemIndex`. Items hidden by the filter box are not touched, so filtering still works, and behavior on Windows is unchanged (no ifdefs).

Tested on macOS 15 (Apple Silicon): the reported hang scenario, multiple checkbox clicks without/with row selection changes in between, select/deselect all, sorting and filtering.